### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ SQLite is an *embedded database*.
 This means that it is intentionally designed to be much simpler than other other database engines
 in order to be *embedded* in other applications.
 (Recall that SQLite [is likely the world's most widely deployed software](https://www.sqlite.org/mostdeployed.html),
-and one of the reasons for this is the easy with which it can be included in other programs.)
+and one of the reasons for this is the ease with which it can be included in other programs.)
 
 One of the ways that SQLite is intentionally simpler is that it does not include an advanced *query optimizer* that can convert SQL expressions into more efficient forms.
 Other databases (like Postgres) can easily optimize both SQL queries into equally efficient forms.
@@ -322,7 +322,7 @@ and so it generates an error.
 
 ## Your Final Task
 
-Let's pretend you're a data analysis working for the city of San Francisco.
+Let's pretend you're a data analyst working for the city of San Francisco.
 You've been tasked with finding the number of businesses who have been inspected by the health inspector and never had a violation.
 As a first pass, you've written the following SQL query.
 ```


### PR DESCRIPTION
Two sentences were gramatically incorrect:

and one of the reasons for this is the **easy** with which it can be included in other programs
-> and one of the reasons for this is the **ease** with which it can be included in other programs.


Let's pretend you're a data **analysis** working for the city of San Francisco.
-> Let's pretend you're a data **analyst** working for the city of San Francisco.




